### PR TITLE
🐛 Fix sitemap configuration

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -82,6 +82,9 @@ const config: Configuration = {
         ? "https://platform-beta.oswaldlabs.com/v1"
         : "http://localhost:7002/v1"
   },
+  sitemap: {
+    hostname: "https://admin.oswaldlabs.com"
+  },
   scrollBehavior() {
     return { x: 0, y: 0 };
   },


### PR DESCRIPTION
Hi @AnandChowdhary ,

First off all, thank you to use my nuxt sitemap module 😉 
I just found a mistake in your `nuxt.config.js` about the following [sitemap.xml](https://admin.oswaldlabs.com/sitemap.xml)

The hostname is missing from the configuration. The option is mandatory if you build nuxt in "spa" or "generate" mode (else the server name will be used by default)
see https://github.com/nuxt-community/sitemap-module#hostname-optional---string